### PR TITLE
Fix building the docker images

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,1 +1,25 @@
-FROM decidim/decidim:latest-deploy
+FROM decidim/decidim:latest
+MAINTAINER info@codegram.com
+
+ENV RAILS_ENV=production
+ENV PORT=3000
+
+# Build a test app in order to be able to precache dependencies. The
+# app itself is removed afterwards as dependencies will get installed
+# under /usr/local/bundle.
+#
+RUN cd /tmp && \
+    decidim decidim_app --skip-bundle && \
+    cd decidim_app && \
+    bundle install --without development,test && \
+    rm -fR decidim_app
+
+ONBUILD COPY Gemfile Gemfile.lock ./
+ONBUILD RUN bundle install
+ONBUILD COPY . .
+ONBUILD RUN bundle install
+ONBUILD RUN bundle exec rake assets:precompile
+
+ENTRYPOINT []
+ENV RAILS_SERVE_STATIC_FILES=true
+CMD bundle exec rails s

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,2 +1,24 @@
-FROM decidim/decidim:latest-deploy
+FROM decidim/decidim:latest
+MAINTAINER info@codegram.com
+
+ENV RAILS_ENV=production
+ENV PORT=3000
+
+# Build a test app in order to be able to precache dependencies. The
+# app itself is removed afterwards as dependencies will get installed
+# under /usr/local/bundle.
+#
+RUN cd /tmp && \
+    decidim decidim_app --skip-bundle && \
+    cd decidim_app && \
+    bundle install --without development,test && \
+    rm -fR decidim_app
+
+ONBUILD COPY Gemfile Gemfile.lock ./
+ONBUILD RUN bundle install
+ONBUILD COPY . .
+ONBUILD RUN bundle install
+ONBUILD RUN bundle exec rake assets:precompile
+
+ENTRYPOINT []
 CMD bundle exec sidekiq -C config/sidekiq.yml


### PR DESCRIPTION
It seems that just using the `decidim-deploy:latest` isn't working, so in order to deploy the new changes we're copying the original Dockerfile.

We should review this afterwards.