### PR TITLE
Add Decidim Barcelona as OAuth provider

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ DECIDIM_VERSION = { git: "https://github.com/decidim/decidim", branch: "master" 
 gem "decidim", DECIDIM_VERSION
 gem "decidim-initiatives", DECIDIM_VERSION
 gem "decidim-consultations", DECIDIM_VERSION
+gem 'omniauth-decidim', git: 'https://github.com/decidim/omniauth-decidim'
 
 gem "uglifier", ">= 1.3.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,6 +186,14 @@ GIT
     decidim-verifications (0.14.0.dev)
       decidim-core (= 0.14.0.dev)
 
+GIT
+  remote: https://github.com/decidim/omniauth-decidim
+  revision: 2b7d087f1b581e06cc82b7716d09cc50e1d0e643
+  specs:
+    omniauth-decidim (0.1.0)
+      omniauth (~> 1.5)
+      omniauth-oauth2 (>= 1.4.0, < 2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -760,6 +768,7 @@ DEPENDENCIES
   listen (~> 3.1.0)
   lograge
   newrelic_rpm
+  omniauth-decidim!
   passenger
   puma (~> 3.0)
   rails_autoscale_agent

--- a/config/initializers/omniauth_decidim.rb
+++ b/config/initializers/omniauth_decidim.rb
@@ -1,0 +1,9 @@
+Devise.setup do |config|
+  config.omniauth :decidim,
+    ENV["DECIDIM_CLIENT_ID"],
+    ENV["DECIDIM_CLIENT_SECRET"],
+    ENV["DECIDIM_SITE_URL"],
+    scope: :public
+end
+
+Decidim::User.omniauth_providers << :decidim


### PR DESCRIPTION
This adds `decidim-omniauth` and its config so we can use Decidim Barcelona as a way to log in or register at Metadecidim.