### PR TITLE
downgrade geocoder to stay in the legacy HERE-maps api credentials

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "uglifier", ">= 1.3.0"
 
 gem "faker", "~> 1.8.4"
 gem "puma", ">= 4.3"
+gem "geocoder", "~> 1.5.2"
 
 group :development, :test do
   gem "byebug", platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -440,7 +440,7 @@ GEM
       activesupport (>= 4.1, < 6.0)
       railties (>= 4.1, < 6.0)
       tzinfo (~> 1.2, >= 1.2.2)
-    geocoder (1.6.2)
+    geocoder (1.5.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     graphiql-rails (1.4.11)
@@ -838,6 +838,7 @@ DEPENDENCIES
   excon (>= 0.71.0)
   faker (~> 1.8.4)
   fog-aws
+  geocoder (~> 1.5.2)
   letter_opener_web (~> 1.3.0)
   listen (~> 3.1.0)
   lograge


### PR DESCRIPTION
Metadecidim still uses legacy authentication method for HERE maps. We should downgrade geocoder until we change it.