### PR TITLE
Disable "decidim" omniauth provider by default

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -30,7 +30,7 @@ default: &default
       client_id: <%= ENV["OMNIAUTH_GOOGLE_CLIENT_ID"] %>
       client_secret: <%= ENV["OMNIAUTH_GOOGLE_CLIENT_SECRET"] %>
     decidim:
-      enabled: true
+      enabled: false
       client_id: <%= ENV["DECIDIM_CLIENT_ID"] %>
       client_secret: <%= ENV["DECIDIM_CLIENT_SECRET"] %>
       site_url: <%= ENV["DECIDIM_SITE_URL"] %>


### PR DESCRIPTION
Right now, by default, the "decidim" omniauth provider is enabled for all tenants. But `meta-decidim` is not using it so it should be disabled.

NOTE: By applying this default setting, other tenants, like, `edu` will have to be configured at system Organization's level manually by a system administrator.