### PR TITLE
Use assets-path in fonts css

### DIFF
--- a/app/assets/stylesheets/metadecidim-theme/_fonts.scss
+++ b/app/assets/stylesheets/metadecidim-theme/_fonts.scss
@@ -1,8 +1,8 @@
 @font-face {
   font-family: 'Barlow';
   src:
-    url('../fonts/barlow-regular.woff2') format('woff2'),
-    url('../fonts/barlow-regular.woff') format('woff');
+    url(asset-path('../fonts/barlow-regular.woff2')) format('woff2'),
+    url(asset-path('../fonts/barlow-regular.woff')) format('woff');
   font-weight: 400;
   font-style: normal;
 }
@@ -10,8 +10,8 @@
 @font-face {
   font-family: 'Barlow';
   src:
-    url('../fonts/barlow-semibold.woff2') format('woff2'),
-    url('../fonts/barlow-semibold.woff') format('woff');
+    url(asset-path('../fonts/barlow-semibold.woff2')) format('woff2'),
+    url(asset-path('../fonts/barlow-semibold.woff')) format('woff');
   font-weight: 600;
   font-style: normal;
 }
@@ -20,8 +20,8 @@
 @font-face {
   font-family: 'Barlow';
   src:
-    url('../fonts/barlow-extrabold.woff2') format('woff2'),
-    url('../fonts/barlow-extrabold.woff') format('woff');
+    url(asset-path('../fonts/barlow-extrabold.woff2')) format('woff2'),
+    url(asset-path('../fonts/barlow-extrabold.woff')) format('woff');
   font-weight: 800;
   font-style: normal;
 }
@@ -30,8 +30,8 @@
 @font-face {
   font-family: 'Barlow';
   src:
-    url('../fonts/barlow-extrabold.woff2') format('woff2'),
-    url('../fonts/barlow-extrabold.woff') format('woff');
+    url(asset-path('../fonts/barlow-extrabold.woff2')) format('woff2'),
+    url(asset-path('../fonts/barlow-extrabold.woff')) format('woff');
   font-weight: 900; //File original: 800. Using 900 to match the default styles
   font-style: normal;
 }


### PR DESCRIPTION
In production, metadecidim-theme fonts are not being resolved.

This is impacting the layout of the site but also its performance as the instance is having lots of requests for this assets that can't be cached by browsers.