### PR TITLE
Disable non confirmation for email users

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -42,6 +42,9 @@ Decidim.configure do |config|
   #
   config.enable_html_header_snippets = true
 
+  # See Devise :confirmable. We ask for confirmation before creating an account.
+  config.unconfirmed_access_for = 0.days
+
   if Rails.application.secrets.sms.values.all?(&:present?)
     config.sms_gateway_service = "SmsGateway"
   end


### PR DESCRIPTION
We're seeing spam, we need to add this setting in the config for disabling unconfirmed users. 
