### PR TITLE
Enforce the disabled non confirmation for email users

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -59,3 +59,5 @@ Decidim::Initiatives.do_not_require_authorization = true
 
 Rails.application.config.i18n.available_locales = Decidim.available_locales
 Rails.application.config.i18n.default_locale = Decidim.default_locale
+
+Devise.allow_unconfirmed_access_for = Decidim.unconfirmed_access_for

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -5,11 +5,9 @@ Decidim.configure do |config|
   config.mailer_sender = Rails.application.secrets.email
   config.authorization_handlers = []
 
-  # Change these lines to set your preferred locales
   config.default_locale = :ca
   config.available_locales = %i[en ca es]
 
-  # Geocoder configuration
   config.maps = {
     provider: :here,
     api_key: Rails.application.secrets.geocoder[:here_api_key],
@@ -20,34 +18,8 @@ Decidim.configure do |config|
     units: :km
   }
 
-  # Custom resource reference generator method
-  # config.resource_reference_generator = lambda do |resource, feature|
-  #   # Implement your custom method to generate resources references
-  #   "1234-#{resource.id}"
-  # end
-
-  # Currency unit
   config.currency_unit = "€"
-
-  # The number of reports which an object can receive before hiding it
-  # config.max_reports_before_hiding = 3
-
-  # Custom HTML Header snippets
-  #
-  # The most common use is to integrate third-party services that require some
-  # extra JavaScript or CSS. Also, you can use it to add extra meta tags to the
-  # HTML. Note that this will only be rendered in public pages, not in the admin
-  # section.
-  #
-  # Before enabling this you should ensure that any tracking that might be done
-  # is in accordance with the rules and regulations that apply to your
-  # environment and usage scenarios. This feature also comes with the risk
-  # that an organization's administrator injects malicious scripts to spy on or
-  # take over user accounts.
-  #
   config.enable_html_header_snippets = true
-
-  # See Devise :confirmable. We ask for confirmation before creating an account.
   config.unconfirmed_access_for = 0.days
 
   if Rails.application.secrets.sms.values.all?(&:present?)

--- a/spec/features/authentication_spec.rb
+++ b/spec/features/authentication_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Authentication', type: :system do
+  let(:organization) { create(:organization) }
+
+  before do
+    switch_to_host(organization.host)
+    visit decidim.root_path
+  end
+
+  describe 'Sign Up' do
+    context 'when using email and password' do
+      it 'ask confirmations on new Users' do
+        find('.sign-up-link').click
+
+        within '.new_user' do
+          fill_in :registration_user_email, with: 'user@example.org'
+          fill_in :registration_user_name, with: 'Responsible Citizen'
+          fill_in :registration_user_nickname, with: 'responsible'
+          fill_in :registration_user_password, with: 'DfyvHn425mYAy2HL'
+          fill_in :registration_user_password_confirmation, with: 'DfyvHn425mYAy2HL'
+          check :registration_user_tos_agreement
+          check :registration_user_newsletter
+          find('*[type=submit]').click
+        end
+
+        expect(page).to have_content('confirmation link')
+      end
+    end
+  end
+end


### PR DESCRIPTION
We're getting spammed, so we want to disallow unconfirmed access in Metadecidim.

Some details related to this PR: 

- We're also going to make this change upstream. Until that's approved we will force it in this app. See https://github.com/decidim/decidim/pull/8233 
- I've actually already made this change here [9 months ago](https://github.com/decidim/metadecidim/pull/79), although it didn't work. This time I'm also adding a spec so we don't have regressions. 
- Related to the previous one, I think it didn't work because we're trying to change an initializer with another initializer or something like that. I've found the correct solution at the [CodeForJapan repository](https://github.com/codeforjapan/decidim-cfj/blob/53232ae5b81a15a611a5c67dc90c4d1170abcd03/config/initializers/decidim.rb#L236)