### PR TITLE
Fix old migration referring to Decidim model

### DIFF
--- a/db/migrate/20170616083641_add_uniqueness_to_name_and_document_number_to_user_groups.decidim.rb
+++ b/db/migrate/20170616083641_add_uniqueness_to_name_and_document_number_to_user_groups.decidim.rb
@@ -2,9 +2,13 @@
 # frozen_string_literal: true
 
 class AddUniquenessToNameAndDocumentNumberToUserGroups < ActiveRecord::Migration[5.0]
+  class UserGroup < ApplicationRecord
+    self.table_name = :decidim_user_groups
+  end
+
   def change
-    Decidim::UserGroup.select(:document_number).group(:document_number).having("count(*) > 1").count.keys.each do |document_number|
-      Decidim::UserGroup.where(document_number: document_number).each_with_index do |user_group, index|
+    UserGroup.select(:document_number).group(:document_number).having("count(*) > 1").count.keys.each do |document_number|
+      UserGroup.where(document_number: document_number).each_with_index do |user_group, index|
         next if index == 0
         user_group.update_attribute(:document_number, "#{document_number} (#{index})")
       end


### PR DESCRIPTION
This old migration was referring to a Decidim model which did not understand it had new columns.

Fixing this the same way as we today with other migrations in the core.

This problem did not exist in the core in the same migration. This is likely something that was added specifically for MetaDecidim.

In order to replicate the issue:
1. `bundle exec rails db:drop db:create`
2. `bundle exec rails db:migrate`
3. See the error