### PR TITLE
Add the env configuration files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,11 @@
 !/log/.keep
 !/tmp/.keep
 
+# Ignore env configuration files
+.env
+.envrc
+.rbenv-vars
+
 # Ignore ruby tmp files
 .byebug_history
 .rspec-failures


### PR DESCRIPTION
As the title says, to prevent developers committing these files which many contain some local secrets.