### PR TITLE
Re-enable term customizer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "decidim", DECIDIM_VERSION
 gem "decidim-initiatives", DECIDIM_VERSION
 gem "decidim-consultations", DECIDIM_VERSION
 gem "decidim-conferences", DECIDIM_VERSION
-#gem "decidim-term_customizer", { git: "https://github.com/mainio/decidim-module-term_customizer", branch: "develop" }
+gem "decidim-term_customizer", { git: "https://github.com/mainio/decidim-module-term_customizer", branch: "develop" }
 
 gem "omniauth-decidim", "0.2.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/mainio/decidim-module-term_customizer
+  revision: c00b70c0beb1af0244917c6ffb882374d4421c50
+  branch: develop
+  specs:
+    decidim-term_customizer (0.27.0)
+      decidim-admin (~> 0.27.0.rc1)
+      decidim-core (~> 0.27.0.rc1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -843,6 +852,7 @@ DEPENDENCIES
   decidim-consultations (= 0.27.0.rc1)
   decidim-dev (= 0.27.0.rc1)
   decidim-initiatives (= 0.27.0.rc1)
+  decidim-term_customizer!
   excon (>= 0.71.0)
   faker
   fog-aws
@@ -868,4 +878,4 @@ RUBY VERSION
    ruby 3.0.2p107
 
 BUNDLED WITH
-   2.3.16
+   2.3.17

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/mainio/decidim-module-term_customizer
-  revision: c00b70c0beb1af0244917c6ffb882374d4421c50
+  revision: cb170d6e88ada190bf5f6946ad5f688995b6cffb
   branch: develop
   specs:
     decidim-term_customizer (0.27.0)


### PR DESCRIPTION
Term customizer should be now compatible with 0.27 at the `develop` branch, so let's re-enable it for Meta Decidim.