### PR TITLE
Update term customizer to the latest revision

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 GIT
   remote: https://github.com/mainio/decidim-module-term_customizer
-  revision: cb170d6e88ada190bf5f6946ad5f688995b6cffb
+  revision: 211c3e2e96f96a1d32310d98e364df66d3f38f69
   branch: develop
   specs:
     decidim-term_customizer (0.27.0)
-      decidim-admin (~> 0.27.0.rc1)
-      decidim-core (~> 0.27.0.rc1)
+      decidim-admin (~> 0.27.0.rc2)
+      decidim-core (~> 0.27.0.rc2)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
It seems that after the update to `0.27.0.rc2`, Term Customizer causes the initiatives and consultations index views to break.

The issue is fixed at https://github.com/mainio/decidim-module-term_customizer/commit/211c3e2e96f96a1d32310d98e364df66d3f38f69.

Test this by trying to request the `/initiatives` or `/consultations` index paths.

Related fixes upstream:
- decidim/decidim#9427
- decidim/decidim#9374

**Edit:** actually it seems these changes were already in RC1 but for some reason, it started breaking only after upgrade to RC2... :smile: 

**Edit 2:** it was already broken on RC1 but the reason why it works currently at MetaDecidim is that Term Customizer is still disabled there.