### PR TITLE
Change main menu

### DIFF
--- a/app/helpers/decidim/menu_helper.rb
+++ b/app/helpers/decidim/menu_helper.rb
@@ -18,5 +18,16 @@ module Decidim
         label: t("layouts.decidim.header.main_menu")
       )
     end
+
+    # Public: Returns the user menu presenter object
+    def user_menu
+      @user_menu ||= ::Decidim::InlineMenuPresenter.new(
+        :user_menu,
+        self,
+        element_class: "tabs-title",
+        active_class: "is-active",
+        label: t("layouts.decidim.user_menu.title")
+      )
+    end
   end
 end

--- a/app/helpers/decidim/menu_helper.rb
+++ b/app/helpers/decidim/menu_helper.rb
@@ -8,14 +8,14 @@ module Decidim
     # We override this from the Decidim standard, so we can present the Metadecidim menu for the
     # Decidim organization in the Multitenant
     def main_menu
-      menu_name = current_organization.name == 'Metadecidim' ? :metadecidim_menu : :menu
+      menu_name = current_organization.name == "Metadecidim" ? :metadecidim_menu : :menu
 
       @main_menu ||= ::Decidim::MenuPresenter.new(
         menu_name,
         self,
-        element_class: 'main-nav__link',
-        active_class: 'main-nav__link--active',
-        label: t('layouts.decidim.header.main_menu')
+        element_class: "main-nav__link",
+        active_class: "main-nav__link--active",
+        label: t("layouts.decidim.header.main_menu")
       )
     end
   end

--- a/app/helpers/decidim/menu_helper.rb
+++ b/app/helpers/decidim/menu_helper.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Decidim
+  # Override helper to manage menus in layout
+  module MenuHelper
+    # Public: Returns the main menu presenter object
+    #
+    # We override this from the Decidim standard, so we can present the Metadecidim menu for the
+    # Decidim organization in the Multitenant
+    def main_menu
+      menu_name = current_organization.name == 'Metadecidim' ? :metadecidim_menu : :menu
+
+      @main_menu ||= ::Decidim::MenuPresenter.new(
+        menu_name,
+        self,
+        element_class: 'main-nav__link',
+        active_class: 'main-nav__link--active',
+        label: t('layouts.decidim.header.main_menu')
+      )
+    end
+  end
+end

--- a/app/packs/stylesheets/decidim/decidim_application.scss
+++ b/app/packs/stylesheets/decidim/decidim_application.scss
@@ -8,3 +8,4 @@
 @import "stylesheets/decidim/metadecidim-theme/css-variables";
 @import "stylesheets/decidim/metadecidim-theme/fonts";
 @import "stylesheets/decidim/metadecidim-theme/typography";
+@import "stylesheets/decidim/metadecidim-theme/navbar";

--- a/app/packs/stylesheets/decidim/metadecidim-theme/_navbar.scss
+++ b/app/packs/stylesheets/decidim/metadecidim-theme/_navbar.scss
@@ -1,0 +1,5 @@
+@media print, screen and (min-width: 40em) {
+  .main-nav__link a {
+    padding: 0.75em 1em;
+  }
+}

--- a/app/packs/stylesheets/decidim/metadecidim-theme/_navbar.scss
+++ b/app/packs/stylesheets/decidim/metadecidim-theme/_navbar.scss
@@ -1,5 +1,5 @@
-@media print, screen and (min-width: 40em) {
-  .main-nav__link a {
+.main-nav__link a {
+  @include breakpoint(medium) {
     padding: 0.75em 1em;
   }
 }

--- a/config/initializers/decidim_menu.rb
+++ b/config/initializers/decidim_menu.rb
@@ -1,0 +1,51 @@
+Decidim.menu :menu do |menu|
+  menu.remove_item :assemblies
+  menu.remove_item :conferences
+  menu.remove_item :initiatives
+  menu.remove_item :consultations
+  menu.remove_item :participatory_processes
+  menu.remove_item :pages
+  menu.remove_item :root
+
+  welcome_path = Decidim::ParticipatoryProcesses::Engine.routes.url_helpers.participatory_process_path("Welcome")
+  menu.add_item :welcome,
+    I18n.t("menu.welcome", scope: "decidim"),
+    welcome_path,
+    position: 10,
+    active: :inclusive
+
+  participate_path = Decidim::ParticipatoryProcesses::Engine.routes.url_helpers.participatory_process_group_path(76)
+  menu.add_item :participate,
+    I18n.t("menu.participate", scope: "decidim"),
+    participate_path,
+    position: 20,
+    active: :inclusive
+
+  meetings_path = Decidim::Meetings::DirectoryEngine.routes.url_helpers.root_path
+  menu.add_item :meetings,
+    I18n.t("menu.meetings", scope: "decidim"),
+    meetings_path,
+    position: 30,
+    active: :inclusive
+
+  governance_path = Decidim::Assemblies::Engine.routes.url_helpers.assembly_path("our-governance")
+  menu.add_item :governance,
+    I18n.t("menu.governance", scope: "decidim"),
+    governance_path,
+    position: 40,
+    active: :inclusive
+
+  news_path = Decidim::ParticipatoryProcesses::Engine.routes.url_helpers.decidim_participatory_process_blogs_path("news", 1719)
+  menu.add_item :news,
+    I18n.t("menu.news", scope: "decidim"),
+    news_path,
+    position: 50,
+    active: :inclusive
+
+  chat_url = "http://chat.decidim.org"
+  menu.add_item :chat,
+    I18n.t("menu.chat", scope: "decidim"),
+    chat_url,
+    position: 60,
+    active: :false
+end

--- a/config/initializers/metadecidim_menu.rb
+++ b/config/initializers/metadecidim_menu.rb
@@ -1,14 +1,6 @@
 # frozen_string_literal: true
 
 Decidim.menu :metadecidim_menu do |menu|
-  menu.remove_item :assemblies
-  menu.remove_item :conferences
-  menu.remove_item :initiatives
-  menu.remove_item :consultations
-  menu.remove_item :participatory_processes
-  menu.remove_item :pages
-  menu.remove_item :root
-
   welcome_path = Decidim::ParticipatoryProcesses::Engine.routes.url_helpers.participatory_process_path("Welcome")
   menu.add_item :welcome,
     I18n.t("menu.welcome", scope: "decidim"),

--- a/config/initializers/metadecidim_menu.rb
+++ b/config/initializers/metadecidim_menu.rb
@@ -1,4 +1,6 @@
-Decidim.menu :menu do |menu|
+# frozen_string_literal: true
+
+Decidim.menu :metadecidim_menu do |menu|
   menu.remove_item :assemblies
   menu.remove_item :conferences
   menu.remove_item :initiatives

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -1,5 +1,12 @@
 ---
 ca:
   decidim:
+    menu:
+      chat: Xat
+      governance: Com ens organitzem
+      meetings: Trobades
+      news: Notícies
+      participate: Participa
+      welcome: Benvinguda
     sms:
       text: "El teu codi per verificar-te a Metadecidim és: %{code}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,13 @@
 ---
 en:
   decidim:
+    menu:
+      chat: Chat
+      governance: Our governance
+      meetings: Meetings
+      news: News
+      participate: Participate
+      welcome: Welcome
     sms:
       text: "Your code to be verified at Metadecidim is: %{code}"
   layouts:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,5 +1,12 @@
 ---
 es:
   decidim:
+    menu:
+      chat: Chat
+      governance: Cómo nos organizamos
+      meetings: Encuentros
+      news: Noticias
+      participate: Participa
+      welcome: Bienvenida
     sms:
       text: "Tu código para verificarte en Metadecidim es: %{code}"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,4 +10,17 @@ if ENV["HEROKU_APP_NAME"].present?
   ENV["DECIDIM_HOST"] = ENV["HEROKU_APP_NAME"] + ".herokuapp.com"
   ENV["SEED"] = true
 end
+
 Decidim.seed!
+
+puts "Making local configurations changes..."
+
+puts "-- Changing the organization's name to Metadecidim"
+Decidim::Organization.first.update!(name: 'Metadecidim')
+
+puts "-- Changing the slugs and IDs to correspond with the ones from the menu"
+Decidim::ParticipatoryProcess.first.update!(slug: 'Welcome')
+Decidim::ParticipatoryProcessGroup.first.update!(id: 76)
+Decidim::Assembly.first.update!(slug: 'our-governance')
+Decidim::ParticipatoryProcess.last.update!(slug: "news")
+Decidim::ParticipatoryProcess.last.components.where(manifest_name: 'blogs').first.update!(id: 1719, name: { en: 'news' })

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -11,6 +11,7 @@ describe 'Visit the home page', type: :system, perform_enqueued: true do
 
   it 'renders the home page' do
     visit decidim.root_path
-    expect(page).to have_content('Home')
+    # By default there isn't any Content Block enabled, so we search a content from the header
+    expect(page).to have_content('Search')
   end
 end

--- a/spec/features/menu_spec.rb
+++ b/spec/features/menu_spec.rb
@@ -4,12 +4,13 @@ require "rails_helper"
 
 describe "Views the menu", type: :system, perform_enqueued: true do
   let(:organization) { create :organization }
+  let(:user) { create :user, :confirmed }
 
   before do
     switch_to_host(organization.host)
   end
 
-  it "has the elements" do
+  it "the main menu has the elements" do
     visit decidim.root_path
 
     within ".navbar" do
@@ -19,10 +20,23 @@ describe "Views the menu", type: :system, perform_enqueued: true do
     end
   end
 
+  it "the user menu has the elements" do
+    login_as user, scope: :user
+    visit decidim.account_path
+
+    within ".side-panel" do
+      expect(page).to have_content("Account")
+      expect(page).to have_content("Notifications settings")
+      expect(page).to have_content("My interests")
+      expect(page).to have_content("My data")
+      expect(page).to have_content("Delete my account")
+    end
+  end
+
   context "with Metadecidim organization" do
     let(:organization) { create :organization, name: "Metadecidim" }
 
-    it "has the elements" do
+    it "the main menu has the Metadecidim elements" do
       visit decidim.root_path
 
       within ".navbar" do

--- a/spec/features/menu_spec.rb
+++ b/spec/features/menu_spec.rb
@@ -11,13 +11,28 @@ describe "Views the menu", type: :system, perform_enqueued: true do
 
   it "has the elements" do
     visit decidim.root_path
+
     within ".navbar" do
-      expect(page).to have_content("Welcome")
-      expect(page).to have_content("Participate")
-      expect(page).to have_content("Meetings")
-      expect(page).to have_content("Our governance")
-      expect(page).to have_content("News")
-      expect(page).to have_content("Chat")
+      expect(page).to have_content("Home")
+      expect(page).to have_content("Initiatives")
+      expect(page).to have_content("Help")
+    end
+  end
+
+  context "with Metadecidim organization" do
+    let(:organization) { create :organization, name: "Metadecidim" }
+
+    it "has the elements" do
+      visit decidim.root_path
+
+      within ".navbar" do
+        expect(page).to have_content("Welcome")
+        expect(page).to have_content("Participate")
+        expect(page).to have_content("Meetings")
+        expect(page).to have_content("Our governance")
+        expect(page).to have_content("News")
+        expect(page).to have_content("Chat")
+      end
     end
   end
 end

--- a/spec/features/menu_spec.rb
+++ b/spec/features/menu_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Views the menu", type: :system, perform_enqueued: true do
+  let(:organization) { create :organization }
+
+  before do
+    switch_to_host(organization.host)
+  end
+
+  it "has the elements" do
+    visit decidim.root_path
+    within ".navbar" do
+      expect(page).to have_content("Welcome")
+      expect(page).to have_content("Participate")
+      expect(page).to have_content("Meetings")
+      expect(page).to have_content("Our governance")
+      expect(page).to have_content("News")
+      expect(page).to have_content("Chat")
+    end
+  end
+end


### PR DESCRIPTION
Preparing for [DecidimFest22](https://meta.decidim.org/conferences/DecidimFest22/program/1698) we wanted to make changes to the organization of Metadecidim.

We've detected that with the current menu, it's not easy to understand what's Metadecidim about. This PR points to the contents on the production instance. 

## Alternatives

As we've discussed in a meeting today, there are other alternative ways of handling this, such as introducing a new module (like https://github.com/OpenSourcePolitics/decidim-module-navbar_links or https://github.com/Platoniq/decidim-module-decidim_awesome), but I don't want to introduce a new dependency here.

As @ahukkanen mentioned, this should probably be implemented on decidim/decidim natively, as changing this menu is a problem that multiple (to not say most) of instances have (cc/ @decidim/product).

## Screenshot

![image](https://user-images.githubusercontent.com/717367/194043580-a8ba1d71-825a-40e1-b0bd-7b496f68c6d1.png)
