### PR TITLE
Change main menu (part II)

### DIFF
--- a/app/packs/stylesheets/decidim/metadecidim-theme/_navbar.scss
+++ b/app/packs/stylesheets/decidim/metadecidim-theme/_navbar.scss
@@ -1,5 +1,20 @@
 .main-nav__link a {
   @include breakpoint(medium) {
     padding: 0.75em 1em;
+    font-size: .9rem;
+  }
+
+  @include breakpoint(large) {
+    font-size: 1rem;
+  }
+}
+
+.topbar__search {
+  @include breakpoint(medium) {
+    max-width: 120px;
+  }
+
+  @include breakpoint(large) {
+    max-width: 220px;
   }
 }

--- a/config/initializers/metadecidim_menu.rb
+++ b/config/initializers/metadecidim_menu.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 Decidim.menu :metadecidim_menu do |menu|
+  menu.add_item :root,
+              I18n.t("menu.home", scope: "decidim"),
+              decidim.root_path,
+              position: 1,
+              active: :exclusive
+
   start_here_path = Decidim::ParticipatoryProcesses::Engine.routes.url_helpers.participatory_process_path("Welcome")
   menu.add_item :start_here,
     I18n.t("menu.start_here", scope: "decidim"),

--- a/config/initializers/metadecidim_menu.rb
+++ b/config/initializers/metadecidim_menu.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 Decidim.menu :metadecidim_menu do |menu|
-  welcome_path = Decidim::ParticipatoryProcesses::Engine.routes.url_helpers.participatory_process_path("Welcome")
-  menu.add_item :welcome,
-    I18n.t("menu.welcome", scope: "decidim"),
-    welcome_path,
+  start_here_path = Decidim::ParticipatoryProcesses::Engine.routes.url_helpers.participatory_process_path("Welcome")
+  menu.add_item :start_here,
+    I18n.t("menu.start_here", scope: "decidim"),
+    start_here_path,
     position: 10,
     active: :inclusive
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,7 +7,7 @@ en:
       meetings: Meetings
       news: News
       participate: Participate
-      welcome: Welcome
+      start_here: Start here
     sms:
       text: "Your code to be verified at Metadecidim is: %{code}"
   layouts:

--- a/spec/features/menu_spec.rb
+++ b/spec/features/menu_spec.rb
@@ -40,6 +40,7 @@ describe "Views the menu", type: :system, perform_enqueued: true do
       visit decidim.root_path
 
       within ".navbar" do
+        expect(page).to have_content("Home")
         expect(page).to have_content("Start here")
         expect(page).to have_content("Participate")
         expect(page).to have_content("Meetings")

--- a/spec/features/menu_spec.rb
+++ b/spec/features/menu_spec.rb
@@ -40,7 +40,7 @@ describe "Views the menu", type: :system, perform_enqueued: true do
       visit decidim.root_path
 
       within ".navbar" do
-        expect(page).to have_content("Welcome")
+        expect(page).to have_content("Start here")
         expect(page).to have_content("Participate")
         expect(page).to have_content("Meetings")
         expect(page).to have_content("Our governance")


### PR DESCRIPTION
After listening to feedback on the last week, we decided to:

1. Add the Home menu item, as now isn't clear how to go to the Home
2. Rename 'Welcome' to 'Start here'

## Screenshot 

![Selection_369](https://user-images.githubusercontent.com/717367/196676591-f3d81608-31e4-40ed-abdc-65a4b1561703.png)
