### PR TITLE
Lock version of `wkhtmltopdf-binary` due to it's size

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,8 @@ gem "redis", "~> 4.7.0"
 # Report GC usage data to StatsD with 'barnes' gem so that Heroku can monitor
 gem "barnes"
 
+gem "wkhtmltopdf-binary", "0.12.6.6"
+
 group :development, :test do
   gem "byebug", platform: :mri
   gem "decidim-dev", DECIDIM_VERSION

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem "redis", "~> 4.7.0"
 # Report GC usage data to StatsD with 'barnes' gem so that Heroku can monitor
 gem "barnes"
 
+# See https://github.com/decidim/metadecidim/pull/130
 gem "wkhtmltopdf-binary", "0.12.6.6"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -821,7 +821,7 @@ GEM
       activesupport
     wisper (2.0.1)
     wisper-rspec (1.1.0)
-    wkhtmltopdf-binary (0.12.6.7)
+    wkhtmltopdf-binary (0.12.6.6)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.12)
@@ -858,6 +858,7 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   web-console
+  wkhtmltopdf-binary (= 0.12.6.6)
 
 RUBY VERSION
    ruby 3.1.1p18


### PR DESCRIPTION
Since the upgrade in #128, the gem `wkhtmltopdf-binary` had an increase in size of about 150Mb. This made impossible to deploy the upgraded app to Heroku since the compressed app would be of over 500Mb.

Here you can see the size of the different versions, and the huge increase between v0.12.6.6 and v0.12.6.7
https://rubygems.org/gems/wkhtmltopdf-binary/versions/0.12.6.6

This problem has also been referenced in their github, as we can see in this [issue](https://github.com/zakird/wkhtmltopdf_binary_gem/issues/55), and that comes from a prior versions.

The `wkhtmltopdf-binary` downloads loads of compressed binaries, and the uses the one for the platform it's running in. Another workaround would be to use a buildpack to remove the unnecessary zips before the compressing step in heroku. That way we could get to a smaller footprint, then having an improved deploy of the application.