### PR TITLE
Fix menu customizations in mobile

### DIFF
--- a/config/initializers/metadecidim_menu.rb
+++ b/config/initializers/metadecidim_menu.rb
@@ -131,5 +131,15 @@ Rails.application.config.to_prepare do
         label: t("layouts.decidim.footer.decidim_title")
       )
     end
+
+    def mobile_breadcrumb_root_menu
+      menu_name = current_organization.name["en"] == "Metadecidim" ? :metadecidim_menu : :mobile_menu
+
+      @mobile_breadcrumb_root_menu ||= ::Decidim::BreadcrumbRootMenuPresenter.new(
+        menu_name,
+        self,
+        container_options: { class: "menu-bar__main-dropdown__menu" }
+      )
+    end
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,7 +17,7 @@ puts "Making local configurations changes..."
 
 puts "-- Changing the organization's name to Metadecidim"
 organization = Decidim::Organization.first
-organization.update!(name: 'Metadecidim')
+organization.update!(name: { en: "Metadecidim" })
 
 puts "-- Applying corporative colors"
 organization.update!(colors: { alert: "#e7131a", primary: "#c8102e", success: "#28a745", warning: "#ffb703", tertiary: "#ebc34b", secondary: "#1a5fb4"})

--- a/spec/features/menu_spec.rb
+++ b/spec/features/menu_spec.rb
@@ -97,5 +97,26 @@ describe "Views the menu", type: :system, perform_enqueued: true do
         end
       end
     end
+    context "when the device is mobile" do
+      before do
+        driven_by(:iphone)
+        switch_to_host(organization.host)
+        visit decidim.root_path
+      end
+
+      specify "the menu is customized" do
+        click_on "Main menu"
+
+        within "#breadcrumb-main-dropdown-mobile" do
+          expect(page).to have_content("Home")
+          expect(page).to have_content("Start here")
+          expect(page).to have_content("Participate")
+          expect(page).to have_content("The Association")
+          expect(page).to have_content("News")
+          expect(page).to have_content("Decidim Fest")
+          expect(page).to have_content("Chat")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
With #13025 we changed the mobile menu, as we needed a bit more control on which elements we display there.

As this application has some customizations regarding this menu, we need to implement those customizations in this new mobile menu.

This PR fixes this customization in the mobile view.

## Testing

1. Run the seeds, so you have the customized Organization name and menu in the desktop view
2. Resize, so you have a mobile menu
3. (Before the patch) see that you have the non-customized menu
4. (After the patch) see that you have the customized menu

## Screenshots

### Before

![imatge](https://github.com/user-attachments/assets/46b77db5-cdfc-4b25-b488-0ba10de101fc)

### After
![imatge](https://github.com/user-attachments/assets/72194a31-a7ae-43f9-832c-f2768b2bf467)