### PR TITLE
Fix Redis TLS configuration

### DIFF
--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# rubocop:disable Style/GlobalVars
+$redis = Redis.new(url: ENV.fetch("REDIS_URL", nil), ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }) if Rails.env.production?
+# rubocop:enable Style/GlobalVars

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+if Rails.env.production?
+  Sidekiq.configure_server do |config|
+    config.redis = { url: ENV.fetch("REDIS_URL", nil), ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE } }
+  end
+
+  Sidekiq.configure_client do |config|
+    config.redis = { url: ENV.fetch("REDIS_URL", nil), ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE } }
+  end
+
+  Sidekiq.strict_args!(false)
+end


### PR DESCRIPTION
After an automatic maintenance task performed by Heroku, we started receiving several errors like: `RedisClient::CannotConnectError (SSL_connect returned=1 errno=0 peeraddr=52.18.173.200:21920 state=error: certificate verify failed (self signed certificate in certificate chain)`

Searching for solutions I found [this](https://help.heroku.com/HC0F8CUS/heroku-key-value-store-connection-issues) from the Heroku Q&A.

With this PR, we configure Redis to accept messages using a TLS layer required in [Redis 6+ in Heroku](https://devcenter.heroku.com/articles/connecting-heroku-redis#connecting-in-ruby) as described in the answer from the link above.
